### PR TITLE
PantherTestCaseTrait is not working without constants

### DIFF
--- a/src/PantherDriver.php
+++ b/src/PantherDriver.php
@@ -40,6 +40,10 @@ class PantherDriver extends CoreDriver
 {
     use PantherTestCaseTrait;
 
+    // PantherTestCaseTrait needs this constants; provided via "\Symfony\Component\Panther\PantherTestCase"
+    public const CHROME = 'chrome';
+    public const FIREFOX = 'firefox';    
+    
     /** @var Client */
     private $client;
     private $started = false;


### PR DESCRIPTION
looking at `\Symfony\Component\Panther\PantherTestCase` constants are provided based on existing classes. But PantherTestCaseTrait itself is not working without having the provided constants

```
   Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Undefined class constant 'CHROME' in vendor/symfony/panther/src/PantherTestCaseTrait.php:179
      Stack trace:
      #0 vendor/robertfausk/mink-panther-driver/src/PantherDriver.php(104): Behat\Mink\Driver\PantherDriver::createPantherClient(Array)
      #1 vendor/behat/mink/src/Session.php(70): Behat\Mink\Driver\PantherDriver->start()
      #2 vendor/behat/mink/src/Session.php(145): Behat\Mink\Session->start()
```

Its a blank composer.json, so not framework provided

```
{
    "autoload": {
        "psr-4": {
            "App\\": "src"
        }
    },
    "require-dev": {
        "robertfausk/behat-panther-extension": "^1.0",
        "behat/behat": "^3.6",
        "phpunit/phpunit": "^9.0"
    }
}
```