### PR TITLE
Allow Symfony Panther 1.0 via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=7.1",
     "behat/mink": "~1.8",
-    "symfony/panther": "~0.7",
+    "symfony/panther": "~0.7|~1.0",
     "ext-dom": "*"
   },
   "require-dev": {


### PR DESCRIPTION
This allows to use with panther 1.0. It looks no breaking changes and its working.

https://symfony.com/blog/announcing-symfony-panther-1-0 recommends this package, so would be good to allow it :)
> BehatPantherExtension is an extension adding support for Panther to the Behat testing framework.